### PR TITLE
inclusão do wick_pdf botão imprimir

### DIFF
--- a/app/controllers/bus_travels_controller.rb
+++ b/app/controllers/bus_travels_controller.rb
@@ -21,7 +21,14 @@ class BusTravelsController < ApplicationController
     @bus_travel = BusTravel.find(params[:id])
     @passenger_trips = @bus_travel.passenger_trips.order('seat ASC').paginate(
         :page => params[:page], :per_page => 10)
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "file_name"   # Excluding ".pdf" extension.
+      end
+    end
   end
+
 
   def new
     if current_user.admin?

--- a/app/views/bus_travels/show.pdf.erb
+++ b/app/views/bus_travels/show.pdf.erb
@@ -13,7 +13,6 @@
     </div>
     <div class="d-flex align-items-center mr-5">
       <button class="btn-printer" id="printPageButton" onClick="window.print();"><i class="fas fa-print"></i></button>
-      <%= link_to  "imprimir", bus_travel_path(@bus_travel,format: "pdf") %>
     </div>
   </div>
   <table style="width:100%" class="mt-3">

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -11,7 +11,7 @@
 WickedPdf.config = {
   # Path to the wkhtmltopdf executable: This usually isn't needed if using
   # one of the wkhtmltopdf-binary family of gems.
-  exe_path: '/usr/local/bin/wkhtmltopdf',
+  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
   # exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
 


### PR DESCRIPTION
- adicionado botão imprimir no show.html.erb do bus_travels, linha 16, se não gostar, só comentar a linha 16;

- wicked_pdf funcionando, para refinar a geração do pdf, editar o (def show) do bus_travels_controller.rb, conforme "Advanced Usage with all available options" do "https://github.com/mileszs/wicked_pdf#advanced-usage-with-all-available-options",

- criado o show.pdf.erb no view do bus_travels, esse arquivo é usado como saída, o que está dentro dele não, por isso é uma cópia do show.html.erb, (pode deixar mais enxuto).


